### PR TITLE
Fixed typo for "values"

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -143,7 +143,7 @@ function renderHeaderAndBorder(color) {
             'right-mid': colorize('╢'),
             'middle': colorize('│')
         },
-        head: [colorize('Token'), colorize('Valeur')]
+        head: [colorize('Token'), colorize('Values')]
     }
 }
 


### PR DESCRIPTION
Since everything was in English, I fixed the spelling for "Values" from "Valeur" (French). Maybe we can add language switch in the config as a feature later on.